### PR TITLE
New command to down old container and up new ones

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -81,7 +81,9 @@ const lunchService = async (sshClient, {
   if (dockerComposeYml) {
     // start server
     // source some startup files first to set up environment
-    const startServiceCommand = startCommand || `source ~/.bash_profile; cd ${remoteDir} && docker-compose down && docker-compose build --force-rm && docker-compose up -d && docker system prune -f`;
+    const oldDockerComposeYml = path.resolve(remoteDir, 'docker-compose-old.yml')
+    const startServiceCommand = startCommand || `source ~/.bash_profile; cd ${remoteDir} && cp ${dockerComposeYml} ${oldDockerComposeYml} && docker-compose -f ${oldDockerComposeYml} down && docker-compose build -f ${dockerComposeYml} --force-rm && docker-compose up -f ${dockerComposeYml} -d && docker system prune -f`;
+
     info('ssh-command', `${host}:${startServiceCommand}`);
     await sshClient.exec(startServiceCommand);
 


### PR DESCRIPTION
Here are the commands that I thought of:
// copy old yml file to another file and use it to down the services
    `cp ${dockerComposeYml} ${oldDockerComposeYml} && docker-compose -f ${oldDockerComposeYml} down`

//use new yml file to up service
    `docker-compose build -f ${dockerComposeYml} --force-rm && docker-compose up -d && docker system prune -f`

Some questions:
- Do we need to remove the old docker-compose.yml after downing the system?
- how do we conduct a test for the new script?

Best Regards